### PR TITLE
Add coding system to currently bare LOINC codes for Growth Chart to have a clearer search specifying both system and code in retrieving vitals

### DIFF
--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -31,7 +31,10 @@ GC.get_data = function() {
     };
 
     var ptFetch = smart.patient.read();
-    var vitalsFetch = smart.patient.api.fetchAll({type: "Observation", query: {code: {$or: ['3141-9', '8302-2', '8287-5', '39156-5', '18185-9', '37362-1', '11884-4']}}});
+    var vitalsFetch = smart.patient.api.fetchAll({type: "Observation", query: {code: {$or: ['http://loinc.org|3141-9',
+      'http://loinc.org|8302-2', 'http://loinc.org|8287-5',
+      'http://loinc.org|39156-5', 'http://loinc.org|18185-9',
+      'http://loinc.org|37362-1', 'http://loinc.org|11884-4']}}});
     var familyHistoryFetch = defaultOnFail(smart.patient.api.fetchAll({type: "FamilyMemberHistory"}), []);
 
     $.when(ptFetch, vitalsFetch, familyHistoryFetch).done(onData);


### PR DESCRIPTION
Currently, the Pediatric Growth Chart SMART app searches for LOINC codes by performing a FHIR token search by just the code (eg, `3141-9`). While this behavior generally works against most FHIR servers and is technically valid, this search is ambiguous as to which coding system the code represents.

A more clear manner to perform these FHIR token searches would be search using both the system and code. So, instead of searching for just `3141-9`, the SMART app would search for `http://loinc.org|3141-9`. Specifying the system is also important in order for this app to work in regions in which LOINC is not used. For instance, there are regions which use SNOMED-CT and by providing the system in the FHIR search, the app makes it very clear to the FHIR server which code system it is interested in.

For reference, [here is an Argonaut mailing list discussion](https://groups.google.com/forum/#!msg/argonaut-project/rzFBJuf-yPU/YGIx7gSJAQAJ) on token based searches that is relevant to this pull request.

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar
