### PR TITLE
Restrict scope to read only Patient and Observation resources of a patient to reflect actual scope and permissions Growth Chart SMART App requires

### DIFF
--- a/launch.html
+++ b/launch.html
@@ -8,7 +8,7 @@
     <script>
       FHIR.oauth2.authorize({
         "client_id": "growth_chart",
-        "scope":  "patient/*.read"
+        "scope":  "patient/Patient.read patient/Observation.read"
       });
     </script>
   </head>


### PR DESCRIPTION
Currently, the Pediatric Growth Chart SMART app requests the scope `patient/*.read` when launching. While this works, the app is requesting far too broad permissions. The result of this is that the user may be suggested to grant the app far more FHIR resource scopes that are actually required of the app.

In order to more accurately reflect the scopes and permissions this app need to run, as well as to provide a good example for other SMART developers, this change requests just the two FHIR scopes this app needs to run: `patient/Patient.read` and `patient/Observation.read`

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar
