### PR TITLE
Use length attribute for WHO growth charts when getting data sets for table view

### DIFF
--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -178,7 +178,7 @@ XDate, setTimeout, getDataSet*/
             case "length":
             case "stature":
             case "lengthandstature":
-                return GC.DATA_SETS[ds + "_STATURE"];
+                return GC.DATA_SETS[ds + "_STATURE"] || GC.DATA_SETS[ds + "_LENGTH"];
             case "weight":
                 return GC.DATA_SETS[ds + "_WEIGHT"];
             case "headc":


### PR DESCRIPTION
Currently, the SMART Growth Chart App in the table view will display length data for a patient regardless of the Growth Chart type being looked at. However, when the table view tries to grab a dataset for length of a WHO Growth Chart type, it is looking for the `WHO_STATURE` field. This is incorrect because the dataset for WHO length is `WHO_LENGTH` in the `GCCurveDataJSON.txt` file. As a result, percentiles and z-scores may not display.

We can fix this by checking if `_STATURE` is the field we look for, and if this field does not exist for the growth chart type being looked at, we instead look for the `_LENGTH` field. Then we can properly display percentiles and z-scores accordingly, and length data will display for any growth chart type.

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar
