### PR TITLE
Display a warning message if the patient record does not have a gender of male or female before the app loads any other data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,6 +48,7 @@ a:hover {
 i {
 	font-style: italic;
 }
+
 #loading-indicator {
 	position: fixed;
 	z-index: 10000000;
@@ -58,26 +59,82 @@ i {
 	height: 100%;
 	width: 100%;
 	background: #4D5B66;
+	display: table;
 }
 
 #loading-indicator h2 {
-	position: absolute;
-	z-index: 2;
-	top: 50%;
-	left: 50%;
-	width  : 150px;
-	margin : -35px auto auto -110px;
+	background: url(../img/spinner2.gif) 10px 50% no-repeat #728391;
+	border-radius: 10px;
+	display: inline-block;
 	line-height : 30px;
 	padding: 10px 10px 10px 60px;
-	color: #FFF;
-	background: url(../img/spinner2.gif) 10px 50% no-repeat #728391;
-	font-size: 18px;
-	border-radius: 10px;
+	text-align: left;
+	width: 150px;
 }
 
 #loading-indicator h2 .msg {
 	font-size: 11px;
 	line-height: normal;
+}
+
+/* onload error message indicator */
+#loading-indicator .container {
+	color: #FFF;
+	display: table-cell;
+	font-size: 18px;
+	height: 100%;
+	text-align: center;
+	vertical-align: middle;
+	width: 100%;
+}
+
+#loading-indicator .error-msg {
+	border-radius: 10px;
+	background-color: #728391;
+	display: none;
+	font-size: 18px;
+	line-height: normal;
+	padding: 10px;
+	text-align: left;
+	width  : 300px;
+}
+
+#loading-indicator .error-msg .display {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+}
+
+#loading-indicator .error-msg .display .icon,
+#loading-indicator .error-msg .display .message {
+	display: table-cell;
+	vertical-align: middle;
+}
+
+#loading-indicator .error-msg .display .icon {
+	width: 50px;
+}
+
+#loading-indicator .error-msg .display .icon .wrapper {
+	display: table;
+	font-family: "Courier New", Courier, monospace;
+	font-size: 40px;
+	height: 35px;
+	table-layout: fixed;
+}
+
+#loading-indicator .error-msg .display .icon .warning,
+#loading-indicator .error-msg .display .icon .baseline {
+	display: table-cell;
+	vertical-align: baseline;
+}
+
+#loading-indicator .error-msg .display .icon .baseline {
+	visibility: hidden;
+}
+
+#loading-indicator .error-msg .display .message {
+	width: 100%;
 }
 
 b, strong {

--- a/index.html
+++ b/index.html
@@ -450,7 +450,15 @@
         </div>
         <div id="dialog"></div>
         <div id="loading-indicator">
-            <h2><span data-translatecontent="STR_180"></span> <div class="msg"></div></h2>
+            <div class="container">
+                <h2><span data-translatecontent="STR_180"></span> <div class="msg"></div></h2>
+                <div class="error-msg">
+                    <div class="display">
+                        <div class="icon"></div>
+                        <div class="message"></div>
+                    </div>
+                </div>
+            </div>
         </div>
     </body>
 </html>

--- a/js/gc-app.js
+++ b/js/gc-app.js
@@ -837,7 +837,14 @@
             }).fail(function(response){
               var msg = response.responseText;
               console.log("Failed.");
-              $("#loading-indicator h2").html(msg); 
+
+              if (response.showMessage) {
+                showMessage(response);
+              }
+              else {
+                $("#loading-indicator h2").html(msg);
+              }
+
               if (response.status === 404) {
                 $("#loading-indicator h2").append($("<button>Make me a fake one!</button>"));
                 $("#loading-indicator button").click(function(){
@@ -847,6 +854,39 @@
                 });
               }
             });
+
+            function showMessage(response) {
+              var message = response.responseText;
+              var icon;
+
+              switch (response.messageType) {
+                case 'warning':
+                  icon = createIcon('&#9888;', 'warning'); // warning triangle
+                  break;
+                default:
+                  icon = createIcon('&#9888;', 'warning'); // defaults to warning triangle
+                  break
+              }
+
+              var $loaderNode = $('#loading-indicator h2');
+              var $messageNode = $('#loading-indicator .error-msg');
+
+              $messageNode.find('.icon').html(icon);
+              $messageNode.find('.message').text(message);
+
+              $loaderNode.fadeOut(function() {
+                  $messageNode
+                    .fadeIn()
+                    .css('display', 'inline-block');
+              });
+
+              // This technique uses the unicode icon's baseline to help vertically center it instead of
+              // the true middle since the icon is not vertically centered within the font. This can be
+              // replaced and simplified if a vertically-centered icon is added to the application.
+              function createIcon(unicode, cssClass) {
+                  return '<div class="wrapper"><div class="' + cssClass + '">' + unicode + '</div><div class="baseline">X</div></div>'
+              }
+            }
         }
 
         function initUIControls(done) {

--- a/js/gc-translations.js
+++ b/js/gc-translations.js
@@ -803,7 +803,11 @@ window.GC = (function(NS) {
             bg : "жена",
             es : "femenino"
         },
-        
+        STR_Error_UnknownGender : {
+            en : "Growth charts can only be displayed for males and females.",
+            es : "Los gráficos de crecimiento solo se pueden mostrar para niños y niñas.",
+            bg : ""
+        },
         "STR_colorPrreset_Default" : {
             en : "Default",
             es : "Defecto",

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -12,6 +12,15 @@ GC.get_data = function() {
     });
   };
 
+  function onErrorWithWarning(msg){
+    console.log("Loading error", arguments);
+    dfd.reject({
+      responseText: msg,
+      showMessage: true,
+      messageType: 'warning',
+    })
+  };
+
   function onReady(smart){
 
     var hidePatientHeader = (smart.tokenResponse.need_patient_banner === false);
@@ -40,6 +49,9 @@ GC.get_data = function() {
     $.when(ptFetch, vitalsFetch, familyHistoryFetch).done(onData);
 
     function onData(patient, vitals, familyHistories){
+      // check patient gender
+      if (!isKnownGender(patient.gender)) onErrorWithWarning(GC.str('STR_Error_UnknownGender'));
+
       var vitalsByCode = smart.byCode(vitals, 'code');
 
       var t0 = new Date().getTime();
@@ -112,6 +124,16 @@ GC.get_data = function() {
       process(vitalsByCode['8287-5'],  units.cm,  p.vitals.headCData);
       process(vitalsByCode['39156-5'], units.any, p.vitals.BMIData);
       processBA(vitalsByCode['37362-1'], p.boneAge);
+
+      function isKnownGender(gender) {
+        switch (gender) {
+          case 'male':
+          case 'female':
+            return true;
+            break;
+        }
+        return false;
+      }
 
       function process(observationValues, toUnit, arr){
         observationValues && observationValues.forEach(function(v){


### PR DESCRIPTION
Currently, the SMART Growth Chart App will load indefinitely with a message saying 

> Please wait...Loading Data

We need to change this to display an appropriate message to the user that the patient record may not have a gender set as male or female, which is needed for the app to run correctly. This will allow for more accuracy in describing what goes wrong in loading the app for this specific use case rather than having a loading screen that loads infinitely. We can have a message displayed saying 

> Growth Charts can only be displayed for males and females.

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar
