### PR TITLE
Remove patient name from parental view height display and re-style date and height values

### DIFF
--- a/js/gc-parental-view.js
+++ b/js/gc-parental-view.js
@@ -400,16 +400,15 @@
                 });
             }
             
-            if (!this._nodes.childName) {
-                this._nodes.childName = this.paper.text(
+            if (!this._nodes.childDateLabel) {
+                this._nodes.childDateLabel = this.paper.text(
                     this.paper.width / 2, 
                     this.paper.height / 2 - 10, 
-                    PATIENT.name
+                    ""
                 ).attr({
                     "text-anchor" : "center",
                     "fill"        : "#25B3DF",
-                    "font-size"   : 13,
-                    "font-weight" : "bold"
+                    "font-size"   : 13
                 });
             }
             
@@ -421,14 +420,14 @@
                 ).attr({
                     "text-anchor" : "center",
                     "fill" : "#25B3DF",
-                    "font-size" : 13
+                    "font-size" : 21
                 });
             }
             
             if (!this._nodes.childHeightImage) {
                 this._nodes.childHeightImage = this.paper.image();
                 this._nodes.childDataRect.toFront();
-                this._nodes.childName.toFront();
+                this._nodes.childDateLabel.toFront();
                 this._nodes.childHeightLabel.toFront();
                 
                 var base  = "img/pview/" + (PATIENT.gender == "male" ? "blue" : "pink"),
@@ -457,24 +456,24 @@
                         "fill-opacity" : heightChild > heightTreshold ? 0.75 : 0 
                     });
                     
-                    this._nodes.childHeightLabel.attr({
+                    this._nodes.childDateLabel.attr({
                         text : lastHeight.agemos === null ?
                             GC.str("STR_158") :
-                            ("on " + 
-                            (new XDate(PATIENT.DOB.getTime())).addMonths(lastHeight.agemos)
-                            .toString(GC.chartSettings.dateFormat) + "\n" 
-                            + heightChild + " cm"),
+                            ((new XDate(PATIENT.DOB.getTime())).addMonths(lastHeight.agemos)
+                                .toString(GC.chartSettings.dateFormat)),
                         y : heightChild > heightTreshold ?
+                            y + 10 :
+                            y - 35
+                    });
+                    
+                    this._nodes.childHeightLabel.attr({
+                        text : lastHeight.agemos === null ?
+                            "" :
+                            heightChild + " cm",
+                        y: heightChild > heightTreshold ?
                             y + 35 :
                             y - 16
                     });
-                    
-                    this._nodes.childName.attr(
-                        "y", 
-                        heightChild > heightTreshold ? 
-                            y + 10 :
-                            y - 40
-                    );
                     
                     this._nodes.childHeightLine.attr({
                         y : y


### PR DESCRIPTION
Currently, in the parental view of the SMART Growth Chart App, there is an issue of the patient's name possibly overlapping with other UI elements on the right-hand side height display if it's long enough to touch the height labels. We need to avoid the situation where a user cannot read the height label for a patient because the name overlaps it. 

To fix this, we can remove the patient name that displays above the patient display. The patient's name already displays on the banner, so it is not absolutely necessary to have the name printed above the patient display. Instead, we will keep the date of the last height measurement chart, as well as the height measurement itself. See attached files for references.
<img width="1214" alt="1_before" src="https://cloud.githubusercontent.com/assets/5685058/15445127/71965b68-1ebf-11e6-807c-7779b113a2d8.png">
<img width="907" alt="2_after" src="https://cloud.githubusercontent.com/assets/5685058/15445129/77b13bee-1ebf-11e6-9e86-c2125236e054.png">

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar
