### PR TITLE
Replace infinite loading spinner to display an appropriate error message to the user if a FHIR resource call fails

### DIFF
--- a/js/gc-translations.js
+++ b/js/gc-translations.js
@@ -737,6 +737,11 @@ window.GC = (function(NS) {
             es : "Cargando datos de la curva",
             bg : "Зареждане данни крива"
         },
+        STR_Error_LoadingApplication : {
+            en : "There was an error loading the application",
+            es : "Se ha producido un error al cargar la aplicación",
+            bg : ""
+        },
         STR_ApplyLocalizations : {
             en : "Apply localizations",
             es : "Aplicar localizaciones",

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -39,14 +39,23 @@ GC.get_data = function() {
       return deferred.promise();
     };
 
-    var ptFetch = smart.patient.read();
-    var vitalsFetch = smart.patient.api.fetchAll({type: "Observation", query: {code: {$or: ['http://loinc.org|3141-9',
-      'http://loinc.org|8302-2', 'http://loinc.org|8287-5',
-      'http://loinc.org|39156-5', 'http://loinc.org|18185-9',
-      'http://loinc.org|37362-1', 'http://loinc.org|11884-4']}}});
-    var familyHistoryFetch = defaultOnFail(smart.patient.api.fetchAll({type: "FamilyMemberHistory"}), []);
+    if (smart.hasOwnProperty('patient')) {
+      var ptFetch = smart.patient.read();
+      var vitalsFetch = smart.patient.api.fetchAll({type: "Observation", query: {code: {$or: ['http://loinc.org|3141-9',
+        'http://loinc.org|8302-2', 'http://loinc.org|8287-5',
+        'http://loinc.org|39156-5', 'http://loinc.org|18185-9',
+        'http://loinc.org|37362-1', 'http://loinc.org|11884-4']}}});
 
-    $.when(ptFetch, vitalsFetch, familyHistoryFetch).done(onData);
+      $.when(ptFetch, vitalsFetch).fail(function() {
+        onErrorWithWarning(GC.str('STR_Error_LoadingApplication'));
+      });
+
+      var familyHistoryFetch = defaultOnFail(smart.patient.api.fetchAll({type: "FamilyMemberHistory"}), []);
+
+      $.when(ptFetch, vitalsFetch, familyHistoryFetch).done(onData);
+    } else {
+      onErrorWithWarning(GC.str('STR_Error_LoadingApplication'));
+    }
 
     function onData(patient, vitals, familyHistories){
       // check patient gender


### PR DESCRIPTION
Currently, if the SMART Growth Chart App cannot successfully retrieve patient information due to a FHIR resource call fail, the app will stay in an infinite "Please Wait...Loading data" state without any indication to the user that an error has occurred. This may occur when an invalid patient id is supplied with the application, or FHIR services may be down overall, thus not being able to find any Observation or FamilyMemberHistory resources for a particular patient. This loading spinner can be misleading to the user who won't understand that the app cannot work at that time.

We can fix this by first checking if a patient is being pulled into the app successfully. If this passes, we can make calls to grab the necessary Observation/FamilyMemberHistory resource. Regardless of the data we get back, if the call was successful, we can continue loading the app. If at any point in the previous two steps does the FHIR call fail, we can replace the loading spinner with an appropriate message to indicate an error has occurred loading the application.

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar
