### PR TITLE
Check the status property on Observations to ensure only final and amended data are being displayed within the application

### DIFF
--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -13,12 +13,24 @@ GC.get_data = function() {
         return false;
     }
 
+    function isValidObservationObj(obj){
+        if (obj.hasOwnProperty('status') && obj.status &&
+            (obj.status.toLowerCase() === 'final' || obj.status.toLowerCase() === 'amended') &&
+            obj.hasOwnProperty('valueQuantity') && obj.valueQuantity.hasOwnProperty('value') &&
+            obj.valueQuantity.hasOwnProperty('code')) {
+            return true;
+        }
+        return false;
+    }
+
     function processBoneAge(boneAgeValues, arr, units) {
         boneAgeValues && boneAgeValues.forEach(function(v){
-            arr.push({
-                date: v.effectiveDateTime,
-                boneAgeMos: units.any(v.valueQuantity)
-            })
+            if (isValidObservationObj(v)) {
+                arr.push({
+                    date: v.effectiveDateTime,
+                    boneAgeMos: units.any(v.valueQuantity)
+                })
+            }
         });
     }
 
@@ -92,10 +104,12 @@ GC.get_data = function() {
 
             function process(observationValues, toUnit, arr){
                 observationValues && observationValues.forEach(function(v){
-                    arr.push({
-                        agemos: months(v.effectiveDateTime, patient.birthDate),
-                        value: toUnit(v.valueQuantity)
-                    })
+                    if (isValidObservationObj(v)) {
+                        arr.push({
+                            agemos: months(v.effectiveDateTime, patient.birthDate),
+                            value: toUnit(v.valueQuantity)
+                        })
+                    }
                 });
             }
 


### PR DESCRIPTION
Currently, the growth chart application will read through all Observations returned from FHIR and display them within the application accordingly on the chart and graph view. However, if an Observation is marked with a status of "entered-in-error" or even "cancelled", we should not expect to pull in these data points into the application. 

To better filter through the Observations during data retrieval, there should be a conditional to check on the `status` property of an Observation value. One such check is for the status on an Observation value to be `final` or `amended`, as these values would most likely be accurate to display within the growth chart. The rest of the Observations that don't match those status values would then be ignored.

@kpshek
@mjhenkes
@kolkheang
@koushic88
@shriniketsarkar