### PR TITLE
Fix datapoints on graphs to be of similar styling regardless of when the datapoint is plotted on the graph

### DIFF
--- a/js/charts/chart.js
+++ b/js/charts/chart.js
@@ -2129,34 +2129,28 @@ Chart.prototype = {
             }, settings),
             set = this.pane.paper.set();
 
-        // The point shadow
-        if (!cfg.firstMonth) {
-            set.push(
-                this.pane.paper.circle(cx, cy + 0.5, cfg.firstMonth ? 6 : 5)
-                .attr({
-                    blur : Raphael.svg ? 1 : 0,
-                    fill : "#000"
-                }).addClass("point")
-            );
-        }
-
         set.push(
 
-            // The point white outline
-            this.pane.paper.circle(cx, cy, cfg.firstMonth ? 5 : 4).attr({
-                stroke : "#FFF",
-                "stroke-opacity": cfg.firstMonth ? 0.75 : 1,
-                "stroke-width" : cfg.firstMonth ? 4 : 2
-            }).addClass("point"),
+          // The shadow
+          this.pane.paper.circle(cx, cy + 0.5, 5).attr({
+              blur : Raphael.svg ? 1 : 0,
+              fill : "#000"
+          }).addClass("point"),
 
-            // The inner point
-            this.pane.paper.circle(cx, cy, 3).attr({
-                fill   : cfg.annotation ?
-                        this.settings.pointsColor :
-                        GC.Util.brighten(this.settings.pointsColor),
-                stroke : "none"/*,
-                title  : cfg.point ? cfg.point.value : "error"*/
-            }).addClass("point")
+          // The point white outline
+          this.pane.paper.circle(cx, cy, 4).attr({
+              stroke : "#FFF",
+              "stroke-opacity": 1,
+              "stroke-width" : 2
+          }).addClass("point"),
+
+          // The inner point
+          this.pane.paper.circle(cx, cy, 3).attr({
+              fill   : cfg.annotation ?
+                this.settings.pointsColor :
+                GC.Util.brighten(this.settings.pointsColor),
+              stroke : "none"
+          }).addClass("point")
         );
 
         this._nodes.push(set);


### PR DESCRIPTION
Currently, if a datapoint is charted on a patient within their first month of being born, it is drawn as a small dot instead of a regular datapoint that is seen past the first month of birth throughout the graph (see screenshots below). 

While this separate styling helps display patient data within the first month of being born, it might make more sense to a physician (if used in the clinical context) to keep all datapoints on the line graphs the same styling. This may clear up any possible confusion about why a datapoint looks different in style compared to the rest.

<img width="300" alt="1_before" src="https://cloud.githubusercontent.com/assets/5685058/26593656/9541fddc-452a-11e7-83a4-6c8321f87706.png">
<img width="348" alt="2_after" src="https://cloud.githubusercontent.com/assets/5685058/26593660/97c92508-452a-11e7-94b2-86bc0a7be209.png">

@kpshek
@mjhenkes
@kolkheang
@koushic88
@shriniketsarkar
