### PR TITLE
Fix styling on Entry Date row for the table view to display the entry date regardless if it is a same-day charting event

### DIFF
--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -255,12 +255,7 @@
             //debugger;
             var age  = new GC.TimeInterval(patient.DOB).setMonths(data.agemos),
                 date = new XDate(patient.DOB.getTime()).addMonths(data.agemos),
-                sameDay = lastDate && lastDate.diffDays(date) < 1,
-                dateText = sameDay ?
-                    '<div style="text-align: center;font-size:20px">&bull;</div>' :
-                    date.toString(
-                        GC.chartSettings.dateFormat
-                    );//,
+                dateText = date.toString(GC.chartSettings.dateFormat);//,
                 // years,
                 // months,
                 // days;
@@ -268,16 +263,11 @@
             // Header - Date
             $('<th/>').append(
                 $('<div class="date"/>').html(dateText)
-            )
-            .appendTo(thr1);
+            ).appendTo(thr1);
 
             // Header - Age
-            $('<th/>')
-                .append( $('<div class=""/>').html(
-                    sameDay ?
-                    date.toString(GC.chartSettings.timeFormat) :
-                    age.toString(shortDateFormat)
-                )
+            $('<th/>').append(
+                $('<div class=""/>').html(age.toString(shortDateFormat))
             ).appendTo(thr2);
 
             $.each(scheme.header.rows, function(j, o) {


### PR DESCRIPTION
Currently, in the table view of the Growth Chart app, if there are 2+ different charting events on a patient within the same day, the first charting event will display the date on the "Entry Date" row, while the other charting events on the same day will display a dot instead of the full date (see screenshots below). 

While the dot styling helps to show same-day events, it might be more clear to the user to just show the date instead of a dot. This way, someone looking at the time of the entry does not have to guess what exactly the dot represents on the table. 

<img width="309" alt="1_before" src="https://cloud.githubusercontent.com/assets/5685058/26594767/9cb5b87a-452e-11e7-9ddb-4a00ed448635.png">
<img width="312" alt="2_after" src="https://cloud.githubusercontent.com/assets/5685058/26594770/9e49cd84-452e-11e7-9f7a-13e2830b3904.png">

@kpshek
@mjhenkes
@kolkheang
@koushic88
@shriniketsarkar
