### PR TITLE
Fix dates mismatch issue where dates for observation’s displayed in the Graph and Table view’s don’t match the observation’s effectiveDateTime as received by the app from service.

### DIFF
--- a/js/chart-pane.js
+++ b/js/chart-pane.js
@@ -1398,6 +1398,7 @@ ChartPane.prototype = {
             html = [];
             this.forEachColumn(function( col, colIndex/*, colsLen*/ ) {
                 $.each(annotated, function(i, entry) {
+                    var dateString = entry.hasOwnProperty('dateString') ? entry.dateString : '';
                     html.push(
                         '<div class="annotation-button" style="left:',
                         inst.months2x(entry.agemos, colIndex),
@@ -1405,8 +1406,7 @@ ChartPane.prototype = {
                         '<div class="details">',
                             '<div class="header">',
                                 '<div class="title">Annotation</div>',
-                                new XDate(GC.App.getPatient().DOB)
-                                    .addMonths(entry.agemos)
+                                new XDate(dateString)
                                     .toString(GC.chartSettings.dateFormat),
                             '</div>',
                             '<div class="content">',

--- a/js/gc-app.js
+++ b/js/gc-app.js
@@ -1490,7 +1490,8 @@
                 return;
             }
 
-            date = (new XDate(PATIENT.DOB)).addMonths(rec.agemos);
+            var dateString = rec.hasOwnProperty('dateString') ? rec.dateString : '';
+            date = new XDate(dateString);
 
             age = new GC.TimeInterval(PATIENT.DOB, date);
 

--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -253,8 +253,9 @@
 
         $.each(model, function( index, data ) {
             //debugger;
+            var dateString = data.hasOwnProperty('dateString') ? data.dateString : '';
             var age  = new GC.TimeInterval(patient.DOB).setMonths(data.agemos),
-                date = new XDate(patient.DOB.getTime()).addMonths(data.agemos),
+                date = new XDate(dateString),
                 dateText = date.toString(GC.chartSettings.dateFormat);//,
                 // years,
                 // months,
@@ -478,8 +479,8 @@
             {
                 label : "Date",
                 get   : function( entry/*, model*/ ) {
-                    return new XDate(patient.DOB.getTime())
-                        .addMonths(entry.agemos)
+                    var dateString = entry.hasOwnProperty('dateString') ? entry.dateString : '';
+                    return new XDate(dateString)
                         .toString(GC.chartSettings.dateFormat);
                 },
                 style : "text-align:left"

--- a/js/gc-parental-view.js
+++ b/js/gc-parental-view.js
@@ -281,10 +281,11 @@
             }, function(key, meta) {
                 var lastEntry = getLastEnryHaving( meta.modelProp ), ds, pct;
                 if (lastEntry) {
+                    var dateString = lastEntry.hasOwnProperty('dateString') ? lastEntry.dateString : '';
                     ds = GC.getDataSet(src, meta.dsType, gender, 0, lastEntry.agemos);
                     out[key].value  = lastEntry[meta.modelProp];
                     out[key].agemos = lastEntry.agemos;
-                    out[key].date   = new XDate(PATIENT.DOB.getTime()).addMonths(lastEntry.agemos);
+                    out[key].date   = new XDate(dateString);
 
                     if (ds) {
                         pct = GC.findPercentileFromX(
@@ -457,11 +458,11 @@
                     "fill-opacity" : heightChild > heightTreshold ? 0.75 : 0
                 });
 
+                var dateString = lastHeight.hasOwnProperty('dateString') ? lastHeight.dateString : '';
                 this._nodes.childDateLabel.attr({
                     text : lastHeight.agemos === null ?
                         GC.str("STR_158") :
-                        ((new XDate(PATIENT.DOB.getTime())).addMonths(lastHeight.agemos)
-                            .toString(GC.chartSettings.dateFormat)),
+                        ((new XDate(dateString)).toString(GC.chartSettings.dateFormat)),
                     y : heightChild > heightTreshold ?
                         y + 10 :
                         y - 35

--- a/js/gc-smart-data.js
+++ b/js/gc-smart-data.js
@@ -483,11 +483,11 @@ window.GC = window.GC || {};
             // Length and Stature
             $.each(this.data.lengthAndStature, function(i, o) {
                 if ( model.hasOwnProperty(o.agemos) ) {
-                    model[ o.agemos ].lengthAndStature = o.value;
+                    model[o.agemos].lengthAndStature = o.value;
                 } else {
-                    model[ o.agemos ] = { "lengthAndStature" : o.value };
+                    model[o.agemos] = { "lengthAndStature" : o.value };
                     if (o.hasOwnProperty('dateString')) {
-                        model[ o.agemos ]['dateString'] = o.dateString;
+                        model[o.agemos]['dateString'] = o.dateString;
                     }
                 }
             });
@@ -495,11 +495,11 @@ window.GC = window.GC || {};
             // Weight
             $.each(this.data.weight, function(i, o) {
                 if ( model.hasOwnProperty(o.agemos) ) {
-                    model[ o.agemos ].weight = o.value;
+                    model[o.agemos].weight = o.value;
                 } else {
-                    model[ o.agemos ] = { "weight" : o.value };
+                    model[o.agemos] = { "weight" : o.value };
                     if (o.hasOwnProperty('dateString')) {
-                        model[ o.agemos ]['dateString'] = o.dateString;
+                        model[o.agemos]['dateString'] = o.dateString;
                     }
                 }
             });
@@ -507,57 +507,57 @@ window.GC = window.GC || {};
             // HEADC
             $.each(this.data.headc, function(i, o) {
                 if ( model.hasOwnProperty(o.agemos) ) {
-                    model[ o.agemos ].headc = o.value;
+                    model[o.agemos].headc = o.value;
                 } else {
-                    model[ o.agemos ] = { "headc" : o.value };
+                    model[o.agemos] = { "headc" : o.value };
                 }
                 if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
-                    model[ o.agemos ]['dateString'] = o.dateString;
+                    model[o.agemos]['dateString'] = o.dateString;
                 }
             });
 
             // BMI
             $.each(this.data.bmi, function(i, o) {
                 if ( model.hasOwnProperty(o.agemos) ) {
-                    model[ o.agemos ].bmi = o.value;
+                    model[o.agemos].bmi = o.value;
                 } else {
-                    model[ o.agemos ] = { "bmi" : o.value };
+                    model[o.agemos] = { "bmi" : o.value };
                 }
                 if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
-                    model[ o.agemos ]['dateString'] = o.dateString;
+                    model[o.agemos]['dateString'] = o.dateString;
                 }
             });
 
             // Bone Age
             $.each(this.boneAge, function(i, o) {
                 if ( model.hasOwnProperty(o.agemos) ) {
-                    model[ o.agemos ].boneAge = o.boneAge;
+                    model[o.agemos].boneAge = o.boneAge;
                 } else {
-                    model[ o.agemos ] = { "boneAge" : o.boneAge };
+                    model[o.agemos] = { "boneAge" : o.boneAge };
                 }
                 if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
-                    model[ o.agemos ]['dateString'] = o.dateString;
+                    model[o.agemos]['dateString'] = o.dateString;
                 }
             });
 
             // Annotations
             $.each(this.annotations, function(i, o) {
                 if ( model.hasOwnProperty(o.agemos) ) {
-                    model[ o.agemos ].annotation = o.annotation;
+                    model[o.agemos].annotation = o.annotation;
                 } else {
-                    model[ o.agemos ] = { "annotation" : o.annotation };
+                    model[o.agemos] = { "annotation" : o.annotation };
                 }
                 if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
-                    model[ o.agemos ]['dateString'] = o.dateString;
+                    model[o.agemos]['dateString'] = o.dateString;
                 }
             });
 
             // Override with custom scratchpad data if available
             if (GC._isPatientDataEditable && GC.scratchpadData && GC.scratchpadData.patientData) {
                 $.each(GC.scratchpadData.patientData, function(i, o) {
-                    model[ o.agemos ] = o;
+                    model[o.agemos] = o;
                     if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
-                        model[ o.agemos ]['dateString'] = o.dateString;
+                        model[o.agemos]['dateString'] = o.dateString;
                     }
                 });
             }

--- a/js/gc-smart-data.js
+++ b/js/gc-smart-data.js
@@ -19,18 +19,25 @@ window.GC = window.GC || {};
         var out = {};
         out.annotation = { txt : this.note };
         out.agemos = patient.DOB.diffMonths(this.date + 1);
+        if (this.hasOwnProperty('dateString')){
+            out.dateString = this.dateString;
+        }
         return out;
     };
 
-    function SmartBoneage(date, boneAgeMos) {
+    function SmartBoneage(date, boneAgeMos, dateString) {
         this.date = new XDate(date);
         this.boneAgeMos = boneAgeMos;
+        this.dateString = dateString;
     }
 
     SmartBoneage.prototype.toGCBoneage = function(patient) {
         var out = {};
         out.boneAge = this.boneAgeMos;
         out.agemos  = patient.DOB.diffMonths(this.date + 1);
+        if (this.hasOwnProperty('dateString')){
+            out.dateString = this.dateString;
+        }
         return out;
     };
 
@@ -278,7 +285,8 @@ window.GC = window.GC || {};
                 agemos: o.hasOwnProperty("agemos") ?
                     o.agemos :
                     patient.DOB.diffMonths(new XDate(o.date)),
-                value : o.value
+                value : o.value,
+                dateString: o.dateString
             });
         }
 
@@ -336,6 +344,9 @@ window.GC = window.GC || {};
 
         if (boneAgeList && boneAgeList.length) {
             $.each(boneAgeList, function(i, o) {
+                if (o.hasOwnProperty("boneAgeMos") && o.hasOwnProperty("date") && o.hasOwnProperty("dateString")) {
+                    o = new SmartBoneage(o.date, o.boneAgeMos, o.dateString);
+                }
                 if (o instanceof SmartBoneage) {
                     patient.boneAge.push(o.toGCBoneage(patient));
                 } else {
@@ -475,6 +486,9 @@ window.GC = window.GC || {};
                     model[ o.agemos ].lengthAndStature = o.value;
                 } else {
                     model[ o.agemos ] = { "lengthAndStature" : o.value };
+                    if (o.hasOwnProperty('dateString')) {
+                        model[ o.agemos ]['dateString'] = o.dateString;
+                    }
                 }
             });
 
@@ -484,6 +498,9 @@ window.GC = window.GC || {};
                     model[ o.agemos ].weight = o.value;
                 } else {
                     model[ o.agemos ] = { "weight" : o.value };
+                    if (o.hasOwnProperty('dateString')) {
+                        model[ o.agemos ]['dateString'] = o.dateString;
+                    }
                 }
             });
 
@@ -494,6 +511,9 @@ window.GC = window.GC || {};
                 } else {
                     model[ o.agemos ] = { "headc" : o.value };
                 }
+                if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
+                    model[ o.agemos ]['dateString'] = o.dateString;
+                }
             });
 
             // BMI
@@ -502,6 +522,9 @@ window.GC = window.GC || {};
                     model[ o.agemos ].bmi = o.value;
                 } else {
                     model[ o.agemos ] = { "bmi" : o.value };
+                }
+                if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
+                    model[ o.agemos ]['dateString'] = o.dateString;
                 }
             });
 
@@ -512,6 +535,9 @@ window.GC = window.GC || {};
                 } else {
                     model[ o.agemos ] = { "boneAge" : o.boneAge };
                 }
+                if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
+                    model[ o.agemos ]['dateString'] = o.dateString;
+                }
             });
 
             // Annotations
@@ -521,12 +547,18 @@ window.GC = window.GC || {};
                 } else {
                     model[ o.agemos ] = { "annotation" : o.annotation };
                 }
+                if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
+                    model[ o.agemos ]['dateString'] = o.dateString;
+                }
             });
 
             // Override with custom scratchpad data if available
             if (GC._isPatientDataEditable && GC.scratchpadData && GC.scratchpadData.patientData) {
                 $.each(GC.scratchpadData.patientData, function(i, o) {
                     model[ o.agemos ] = o;
+                    if (!model[o.agemos].hasOwnProperty("dateString") && o.hasOwnProperty('dateString')) {
+                        model[ o.agemos ]['dateString'] = o.dateString;
+                    }
                 });
             }
 

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -28,6 +28,7 @@ GC.get_data = function() {
             if (isValidObservationObj(v)) {
                 arr.push({
                     date: v.effectiveDateTime,
+                    dateString: v.effectiveDateTime,
                     boneAgeMos: units.any(v.valueQuantity)
                 })
             }
@@ -107,7 +108,8 @@ GC.get_data = function() {
                     if (isValidObservationObj(v)) {
                         arr.push({
                             agemos: months(v.effectiveDateTime, patient.birthDate),
-                            value: toUnit(v.valueQuantity)
+                            value: toUnit(v.valueQuantity),
+                            dateString: v.effectiveDateTime
                         })
                     }
                 });


### PR DESCRIPTION
Issue : The open source version of growth chart has a mismatch in the observations (i.e height, weight etc) being displayed on the Graph and Table Views. After some investigation, the issue seems to be with the way the app processes date for an observation. The app converts the dateString received from the resource call into `Age in Months` using the XDate library. Then the app converts the `Age in Months` back to a Date String for displaying it on the Graph and Table View for that observation. The XDate library computes this Date String incorrectly thus resulting in a date which could be off by a few days from the actual date of the observation. 

More Info on this Issue : smart-on-fhir#35

Fix : This PR fixes the display to consume the effectiveDateTime received with the observation as a string. We pass down a separate key `dateString` with the apps object for observations and use it later on to display the string directly thus avoiding any conversions using the XDate library. 

Consideration: This fix adds a new variable `dateString` and does not alter any of the apps existing logic to handle a date object for an observation.

@kpshek
@zplata
@mjhenkes
@kolkheang