### PR TITLE
Get Parental Heights from LOINCs if FamilyHistory resource is unavailable.

### DIFF
--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -185,6 +185,26 @@ GC.get_data = function() {
                 }
             });
 
+            // Handle Father and Mother heights :
+
+            // Height of Father using LOINC if familyHistory is not available
+            var observations = vitalsByCode['83845-8'];
+            if (observations && observations.length > 0 && p.familyHistory.father.height === null){
+                if (isValidObservationObj(observations[0])) {
+                    p.familyHistory.father.height = units.cm(observations[0].valueQuantity);
+                    p.familyHistory.father.isBio = true;
+                }
+            }
+
+            // Height of Mother using LOINC if familyHistory is not available
+            observations = vitalsByCode['83846-6'];
+            if (observations && observations.length > 0 && p.familyHistory.mother.height === null){
+                if (isValidObservationObj(observations[0])) {
+                    p.familyHistory.mother.height = units.cm(observations[0].valueQuantity);
+                    p.familyHistory.mother.isBio = true;
+                }
+            }
+
             window.data = p;
             console.log("Check out the patient's growth data: window.data");
             dfd.resolve(p);
@@ -210,7 +230,9 @@ GC.get_data = function() {
                                 'http://loinc.org|39156-5',
                                 'http://loinc.org|18185-9',
                                 'http://loinc.org|37362-1',
-                                'http://loinc.org|11884-4'
+                                'http://loinc.org|11884-4',
+                                'http://loinc.org|83845-8',
+                                'http://loinc.org|83846-6'
                             ]
                         }
                     }

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -185,9 +185,7 @@ GC.get_data = function() {
                 }
             });
 
-            // Handle Father and Mother heights :
-
-            // Height of Father using LOINC if familyHistory is not available
+            // Handle father's and mother's heights using LOINC when Family History FHIR resource is not available.
             var observations = vitalsByCode['83845-8'];
             if (observations && observations.length > 0 && p.familyHistory.father.height === null){
                 if (isValidObservationObj(observations[0])) {
@@ -195,8 +193,6 @@ GC.get_data = function() {
                     p.familyHistory.father.isBio = true;
                 }
             }
-
-            // Height of Mother using LOINC if familyHistory is not available
             observations = vitalsByCode['83846-6'];
             if (observations && observations.length > 0 && p.familyHistory.mother.height === null){
                 if (isValidObservationObj(observations[0])) {


### PR DESCRIPTION
Issue : The open source version of growth chart gets the Father/Mother heights from the FamilyHistory resource. If an EHR has not implemented the Family History FHIR resource then the application provides for no other way to automatically get these heights from the patients chart thus leaving the user with an option to manually enter the heights using the Settings gear icon. 

Solution :  If the EHR has availability for Observation's FHIR resource then it can leverage 2 Parental Height LOINC's(`83845-8` , `83846-6`) to fetch the necessary heights. This change adds the ability to use LOINC's using the Observation's resource to fetch Father/Mother heights from the EHR. 

Consideration: In this change the app attempts to make the FamilyHistory resource call but also request observation's for these additional LOINC's (for parental heights) and uses the heights returned by the LOINC's if FamilyHistory resource call fails. 

@kpshek
@zplata
@mjhenkes
@kolkheang 