### PR TITLE
Add LOINC 85151-9 to get Bone Age keeping old LOINC 37362-1 as secondary source.

### DIFF
--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -161,6 +161,8 @@ GC.get_data = function() {
             process(vitalsByCode['8302-2'],  units.cm,  p.vitals.lengthData);
             process(vitalsByCode['8287-5'],  units.cm,  p.vitals.headCData);
             process(vitalsByCode['39156-5'], units.any, p.vitals.BMIData);
+            //Bone Age: The reason to prefer the LOINC 85151-9 over 37362-1 is because 37362-1 is a LOINC for radiology report (document)
+            // and may not represent a quantitative value which the app needs.
             var boneAgeObservations = vitalsByCode['85151-9'] ? vitalsByCode['85151-9'] : vitalsByCode['37362-1'];
             processBoneAge(boneAgeObservations, p.boneAge, units);
 

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -161,7 +161,10 @@ GC.get_data = function() {
             process(vitalsByCode['8302-2'],  units.cm,  p.vitals.lengthData);
             process(vitalsByCode['8287-5'],  units.cm,  p.vitals.headCData);
             process(vitalsByCode['39156-5'], units.any, p.vitals.BMIData);
-            processBoneAge(vitalsByCode['37362-1'], p.boneAge, units);
+            var boneAgeObservations = vitalsByCode['85151-9'] ? vitalsByCode['85151-9'] : vitalsByCode['37362-1'];
+            processBoneAge(boneAgeObservations, p.boneAge, units);
+
+
 
             $.each(familyHistories, function(index, fh) {
                 if (fh.resourceType === "FamilyMemberHistory") {
@@ -210,7 +213,8 @@ GC.get_data = function() {
                                 'http://loinc.org|39156-5',
                                 'http://loinc.org|18185-9',
                                 'http://loinc.org|37362-1',
-                                'http://loinc.org|11884-4'
+                                'http://loinc.org|11884-4',
+                                'http://loinc.org|85151-9'
                             ]
                         }
                     }


### PR DESCRIPTION
Issue: Growth Chart app requests the LOINC `37362-1` [1] for Bone Age. This Bone Age LOINC is for the radiology report (document) and not actually for quantitative value.
Hence after checking with the Terminologist's at Cerner we considered the LOINC `85151-9`  [2] to be more aligned with the apps requirement of a quantitative value for Bone Age.

[1] https://s.details.loinc.org/LOINC/37362-1.html?sections=Simple
[2] https://s.details.loinc.org/LOINC/85151-9.html?sections=Simple

Changes: This PR adds the new LOINC and considers it as a primary source to get Bone Age and uses the old loinc as secondary. 

@kpshek 
@mjhenkes 
@kolkheang 
@zplata 