### PR TITLE
Added more LOINC’s to the app to request with the Observation’s Resource.

### DIFF
--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -74,7 +74,7 @@ GC.get_data = function() {
                 onErrorWithWarning(GC.str('STR_Error_UnknownGender'));
             }
 
-            var vitalsByCode = smart.byCode(vitals, 'code');
+            var vitalsByCode = smart.byCodes(vitals, 'code');
 
             // Initialize an empty patient structure
             var p = {
@@ -125,10 +125,10 @@ GC.get_data = function() {
             p.demographics.birthday = patient.birthDate;
             p.demographics.gender = patient.gender;
 
-            var gestAge = vitalsByCode['18185-9'];
-            if (gestAge === undefined) {
+            var gestAge = vitalsByCode('18185-9');
+            if (gestAge === undefined || gestAge.length == 0) {
                 //handle an alternate mapping of Gest Age used by Cerner
-                gestAge = vitalsByCode['11884-4'];
+                gestAge = vitalsByCode('11884-4');
             }
 
             if (gestAge && gestAge.length > 0) {
@@ -157,11 +157,13 @@ GC.get_data = function() {
             }
 
             var units = smart.units;
-            process(vitalsByCode['3141-9'], units.kg, p.vitals.weightData);
-            process(vitalsByCode['8302-2'],  units.cm,  p.vitals.lengthData);
-            process(vitalsByCode['8287-5'],  units.cm,  p.vitals.headCData);
-            process(vitalsByCode['39156-5'], units.any, p.vitals.BMIData);
-            processBoneAge(vitalsByCode['37362-1'], p.boneAge, units);
+
+            process(vitalsByCode('3141-9','29463-7','8335-2'), units.kg, p.vitals.weightData);
+            process(vitalsByCode('8302-2','8301-4','3137-7'),  units.cm,  p.vitals.lengthData);
+            process(vitalsByCode('8287-5'),  units.cm,  p.vitals.headCData);
+            process(vitalsByCode('39156-5'), units.any, p.vitals.BMIData);
+            var boneAgeObservations = vitalsByCode('85151-9') ? vitalsByCode('85151-9') : vitalsByCode('37362-1');
+            processBoneAge(boneAgeObservations, p.boneAge, units);
 
             $.each(familyHistories, function(index, fh) {
                 if (fh.resourceType === "FamilyMemberHistory") {
@@ -204,13 +206,34 @@ GC.get_data = function() {
                     query: {
                         code: {
                             $or: [
+                                //Weight
                                 'http://loinc.org|3141-9',
+                                'http://loinc.org|29463-7',
+                                'http://loinc.org|8335-2',
+
+                                //Height
                                 'http://loinc.org|8302-2',
+                                'http://loinc.org|8301-4',
+                                'http://loinc.org|3137-7',
+
+                                //Head Circumference
                                 'http://loinc.org|8287-5',
+
+                                //BMI
                                 'http://loinc.org|39156-5',
-                                'http://loinc.org|18185-9',
+
+                                //Bone Age
+                                'http://loinc.org|85151-9',
                                 'http://loinc.org|37362-1',
-                                'http://loinc.org|11884-4'
+
+                                //Gestsational Age
+                                'http://loinc.org|18185-9',
+                                'http://loinc.org|11884-4',
+
+                                //Parental Height Father
+                                'http://loinc.org|83845-8',
+                                //Parental Height Mother
+                                'http://loinc.org|83846-6'
                             ]
                         }
                     }


### PR DESCRIPTION
Currently the open source growth chart app requests observations for certain LOINC's (weight, height, bmi, bone age). Depending on how the mapping for these LOINC's is setup in the EHR (mapping it to the data) it is possible that the FHIR queries may or may not result in observations. 
This PR adds more LOINC's for weight, height, bone age, gestational age and parental heights. This covers more mappings in the EHR thus improving the chances of getting observations. 

@kpshek 
@zplata 
@kolkheang 
@mjhenkes 
