### PR TITLE
Round charted values to decimal precision of 3 under the NICU toggle. Fix defect on head circumference z-scores and percentiles not displaying on table view. Only consume latest chart on same-day charting occurences. Display all gestational age formats regardless of the format returned by FHIR service data for this result

### DIFF
--- a/js/gc-chart-config.js
+++ b/js/gc-chart-config.js
@@ -24,7 +24,7 @@ window.GC = window.GC || {};
     // been stored on the server too)
     // =========================================================================
     var readOnlySettings = {
-        fileRevision : 208,
+        fileRevision : 209,
 
         // See the toString method for the rendering template
         version : {
@@ -169,12 +169,12 @@ window.GC = window.GC || {};
         nicu : false,
 
         roundPrecision : {
-            length     : { std : 1, nicu : 1 },
+            length     : { std : 1, nicu : 3 },
             weight     : { std : 1, nicu : 3 },
-            headc      : { std : 1, nicu : 1 },
-            bmi        : { std : 1, nicu : 1 },
-            percentile : { std : 0, nicu : 0 },
-            zscore     : { std : 2, nicu : 2 },
+            headc      : { std : 1, nicu : 3 },
+            bmi        : { std : 1, nicu : 3 },
+            percentile : { std : 0, nicu : 3 },
+            zscore     : { std : 2, nicu : 3 },
             velocity   : { std : "year", nicu : "day" }
         },
 

--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -105,6 +105,17 @@
         return EMPTY_MARK;
     }
 
+    function monthsInDays(d) {
+        var diffDays = -1 * (new XDate(d)).diffDays(GC.App.getPatient().DOB);
+        var weeksInMonth = 4.348214285714286;
+        if (diffDays < 0) {
+            return ((Math.ceil(diffDays))/7)/ weeksInMonth;
+        }
+        else {
+            return ((Math.floor(diffDays))/7)/ weeksInMonth;
+        }
+    }
+
     function getPercentile( entry, prop ) {
         if (entry.hasOwnProperty(prop)) {
             var ds = getDataSet(prop), pct;
@@ -113,12 +124,13 @@
                     entry[prop],
                     ds,
                     GC.App.getGender(),
-                    entry.agemos
+                    monthsInDays(entry.display)
                 );
                 if ( isNaN(pct) || !isFinite(pct) ) {
                     return EMPTY_MARK;
                 }
-                return GC.Util.roundToPrecision(pct * 100, 0);
+                var prec = GC.chartSettings.roundPrecision.percentile[GC.chartSettings.nicu ? "nicu" : "std"];
+                return GC.Util.roundToPrecision(pct * 100, prec);
             }
         }
         return EMPTY_MARK;
@@ -137,7 +149,8 @@
                 if ( isNaN(z) || !isFinite(z) ) {
                     return EMPTY_MARK;
                 }
-                return GC.Util.roundToPrecision(z, 1);
+                var prec = GC.chartSettings.roundPrecision.percentile[GC.chartSettings.nicu ? "nicu" : "std"];
+                return GC.Util.roundToPrecision(z * 100, prec);
             }
         }
         return EMPTY_MARK;
@@ -178,7 +191,7 @@
         case "weight":
             return GC.DATA_SETS[ds + "_WEIGHT"];
         case "headc":
-            return GC.DATA_SETS[ds + "_HEAD_CIRCUMFERENCE_INF"];
+            return GC.DATA_SETS[ds + "_HEADC"];
         }
     }
 

--- a/js/gc-smart-data.js
+++ b/js/gc-smart-data.js
@@ -61,13 +61,17 @@ window.GC = window.GC || {};
             }
 
             // If this record was NOT made at the same day as the previous one -
-            // get it, but first get the buffer if not empty
+            // get it, but first get the buffer if not empty and overwrite first same day entry
             else {
                 if (buffer > -1) {
-                    out.push(data[buffer]);
+                    out[out.length-1] = data[buffer];
                     buffer = -1;
                 }
                 out.push(rec);
+            }
+
+            if (idx === len-1 && buffer !== -1) {
+                out[out.length - 1] = rec;
             }
 
             lastDay = day;
@@ -278,7 +282,8 @@ window.GC = window.GC || {};
                 agemos: o.hasOwnProperty("agemos") ?
                     o.agemos :
                     patient.DOB.diffMonths(new XDate(o.date)),
-                value : o.value
+                value : o.value,
+                display: o.display
             });
         }
 
@@ -486,6 +491,21 @@ window.GC = window.GC || {};
                     model[ o.agemos ] = { "weight" : o.value };
                 }
             });
+
+            // Display
+            var setDisplayInModel = function(i, o) {
+                if ( model.hasOwnProperty(o.agemos) ) {
+                    if (!model.hasOwnProperty("display")) {
+                        model[o.agemos].display = o.display;
+                    }
+                } else {
+                    model[ o.agemos ] = { "display" : o.display };
+                }
+            };
+
+            $.each(this.data.weight, setDisplayInModel);
+            $.each(this.data.headc, setDisplayInModel);
+            $.each(this.data.lengthAndStature, setDisplayInModel);
 
             // HEADC
             $.each(this.data.headc, function(i, o) {

--- a/launch.html
+++ b/launch.html
@@ -8,7 +8,7 @@
     <script>
       FHIR.oauth2.authorize({
         "client_id": "growth_chart",
-        "scope":  "patient/Patient.read patient/Observation.read"
+        "scope":  "patient/Patient.read patient/Observation.read launch profile openid online_access"
       });
     </script>
   </head>

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -107,7 +107,8 @@ GC.get_data = function() {
                     if (isValidObservationObj(v)) {
                         arr.push({
                             agemos: months(v.effectiveDateTime, patient.birthDate),
-                            value: toUnit(v.valueQuantity)
+                            value: toUnit(v.valueQuantity),
+                            display: v.effectiveDateTime
                         })
                     }
                 });
@@ -140,6 +141,9 @@ GC.get_data = function() {
                             40;
 
                 if (typeof qty == 'string') {
+                    if (qty.indexOf("weeks") > 0 ) {
+                        qty = qty.replace(/ weeks/gi, "W");
+                    }
                     qty.replace(/(\d+)([WD])\s*/gi, function(token, num, code) {
                         num = parseFloat(num);
                         if (code.toUpperCase() == 'D') {


### PR DESCRIPTION
Currently, with a NICU toggle, on the chart view, charted values will display 0 decimal places. To allow for a more accurate reading, we could display 3 decimal places for these charted values if the toggle is set to `true`. 

Additionally, head circumference z-scores and percentiles were not displaying as a defect from reading the wrong property on an object, so we should fix this with the correct property to properly display the values for these calculations. 

Also currently, if there are two or more chartings on the same day, we want to make sure the charting only takes the latest of the chartings to make the chart seem more accurate and concise. This PR should fix this issue and display only the last chart on a same-day occurrence.

Lastly, the Cerner FHIR server result for Gest. Age may be inconsistent in the formatting (seeing results such as 32W or 32 Weeks), so we should fix to accommodate for both formats to display (if gest age even displays).

These changes were contributed by Intermountain HC.

@kolkheang 
@shriniketsarkar 
@koushic88
@mjhenkes 