### PR TITLE
Use patient BMI percentile if available to calculate obesity status.

### DIFF
--- a/js/gc-translations.js
+++ b/js/gc-translations.js
@@ -848,8 +848,17 @@ window.GC = (function(NS) {
             en : "Greyscale - High Contrast",
             es : "Gris - аlto contraste",
             bg : "Черно-бял - висок контраст"
+        },
+        "STR_BMIRange_Male" : {
+            en : "The healthy BMI for his age and height is",
+            es : "El IMC saludable para su edad y altura es",
+            bg : ""
+        },
+        "STR_BMIRange_Female" : {
+            en : "The healthy BMI for her age and height is",
+            es : "El IMC saludable para su edad y altura es",
+            bg : ""
         }
-
     };
 
     NS.locales = locales;


### PR DESCRIPTION
Currently, the obesity measure for a patient is calculated using the weight percentile rather than the BMI percentile. We need to fix this to use BMI percentile if available to calculate the status of obesity. [According to the CDC](http://www.cdc.gov/obesity/childhood/defining.html), the definition of childhood obesity is based upon BMI percentile. If the BMI data is not available to pull from, the application can go back to using weight values to determine obesity status.

This change was made to the upstream project originally.

@kolkheang 
@shriniketsarkar 
@koushic88
@rishabh92